### PR TITLE
Init selection as empty array.

### DIFF
--- a/ui/select.reel/select.js
+++ b/ui/select.reel/select.js
@@ -113,6 +113,7 @@ var Select = exports.Select =  NativeControl.specialize(/** @lends module:"monta
             if(!this.contentController) {
                 var contentController = new RangeController();
                 contentController.content = value;
+                contentController.selection = [];
                 this.contentController = contentController;
             }
 


### PR DESCRIPTION
Sets the initial value of contentController.selection to an empty array. See also: https://github.com/montagejs/montage/pull/1320
