### PR TITLE
Quick fix when changing the content of a select component by an empty array

### DIFF
--- a/ui/select.reel/select.js
+++ b/ui/select.reel/select.js
@@ -179,7 +179,7 @@ var Select = exports.Select =  NativeControl.specialize(/** @lends module:"monta
                 length = selectedIndexes.length,
                 valuePath;
 
-            if(length > 0) {
+            if(length > 0 && content) {
                 arr = [];
                 valuePath = this.valuePropertyPath || 'value';
 


### PR DESCRIPTION
If I change the content of a select component (which one is already set) by an empty array I get the following error: Cannot read property 'value' of undefined.

http://montagejs.github.io/mfiddle/#!/11405754

But I'm not sure it's the best way to fix it, because if there is some selected indexes, that should say there is some content...
